### PR TITLE
auto-resize plot to fit space

### DIFF
--- a/src/dataPlotWidget.cpp
+++ b/src/dataPlotWidget.cpp
@@ -1,11 +1,12 @@
 #include <QPainter>
 #include <QApplication>
+#include <QResizeEvent>
 #include "dataPlotWidget.h"
 
 DataPlotWidget::DataPlotWidget(QWidget * parent)
  : QWidget(parent)
 {
-    setFixedSize(PLOT_WIDTH, PLOT_HEIGHT);
+    setMinimumSize(PLOT_WIDTH, PLOT_HEIGHT);
 
     currentCount = 0;
     currentIndex = 0;
@@ -135,7 +136,7 @@ void DataPlotWidget::drawDataPlot()
 
     }
 
-    painter.drawText(5, 12, "Max: " + QString::number(dataMax));
+    painter.drawText(5, 24, "Max: " + QString::number(dataMax));
     painter.drawText(5, PLOT_HEIGHT - 2, "Min: " + QString::number(dataMin));
 
     QTransform trans(1, 0, 0, 0, -1, 0, 0, 0, 1);
@@ -182,8 +183,6 @@ void DataPlotWidget::drawDataPlot()
 
 void DataPlotWidget::resetPlot()
 {
-    setFixedSize(PLOT_WIDTH, PLOT_HEIGHT);
-
     currentCount = 0;
     currentIndex = 0;
 
@@ -215,4 +214,10 @@ void DataPlotWidget::setDataLength(int length)
     }
 
     resetPlot();
+}
+
+void DataPlotWidget::resizeEvent(QResizeEvent *event)
+{
+    PLOT_WIDTH = event->size().width();
+    PLOT_HEIGHT = event->size().height();
 }

--- a/src/dataPlotWidget.h
+++ b/src/dataPlotWidget.h
@@ -29,19 +29,22 @@ class DataPlotWidget : public QWidget
         void resetPlot();
         void setDataLength(int length);
 
+        int PLOT_WIDTH = 640;
+        int PLOT_HEIGHT = 240;
+
         static const int DEFAULT_DATA_LENGTH = 100;
         static const int NUM_PLOTS = 4;
-        static const int PLOT_WIDTH = 640;
-        static const int PLOT_HEIGHT = 240;
         static const int PEN_WIDTH = 1;
         static const int PEN_HIGHLIGHT_WIDTH = 2;
+
     private:
         QPainter painter;
 
         void paintEvent(QPaintEvent * event);
         int getPlotY(float val, float dataMin, float dataMax);
         void drawDataPlot();
-        
+        void resizeEvent(QResizeEvent *event) override;
+
         int lastLimit;
         int dataLength;
         float ** dataArray;

--- a/src/plotHolderWidget.cpp
+++ b/src/plotHolderWidget.cpp
@@ -7,30 +7,27 @@
 PlotHolderWidget::PlotHolderWidget(QWidget *parent)
  : QWidget(parent)
 {
-    mainLayout = new QVBoxLayout;
-    setLayout(mainLayout);
     setWindowTitle("Plot Window");
 
-    dataPlotWidget = new DataPlotWidget();
+    mainLayout = new QVBoxLayout;
+    setLayout(mainLayout);
 
-    plotLayout = new QVBoxLayout;
-    buttonLayout = new QHBoxLayout;
-
-    currentDataLength = new QLabel;
-    currentDataLength->setText("Current Window Sample Length: " + QString::number(DataPlotWidget::DEFAULT_DATA_LENGTH));
+    resetButton = new QPushButton("Reset Plot", this);
+    mainLayout->addWidget(resetButton);
 
     plotLength = new QSlider;
     plotLength->setMinimum(50);
     plotLength->setMaximum(10000);
     plotLength->setOrientation(Qt::Horizontal);
-
-    mainLayout->addLayout(buttonLayout);
     mainLayout->addWidget(plotLength);
+
+    currentDataLength = new QLabel;
+    currentDataLength->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+    currentDataLength->setText("Current Window Sample Length: " + QString::number(DataPlotWidget::DEFAULT_DATA_LENGTH));
     mainLayout->addWidget(currentDataLength);
 
-    resetButton = new QPushButton("Reset Plot", this);
-    buttonLayout->addWidget(resetButton);
-
+    plotLayout = new QVBoxLayout;
+    dataPlotWidget = new DataPlotWidget();
     plotLayout->addWidget(dataPlotWidget);
     mainLayout->addLayout(plotLayout);
 

--- a/src/plotHolderWidget.h
+++ b/src/plotHolderWidget.h
@@ -29,7 +29,7 @@ class PlotHolderWidget : public QWidget
     public:
         PlotHolderWidget(QWidget * parent = 0);
         void update(float * values, bool * enabled);
-        
+
         DataPlotWidget * dataPlotWidget;
         QSlider * plotLength;
         QLabel * currentDataLength;
@@ -37,7 +37,6 @@ class PlotHolderWidget : public QWidget
         QVBoxLayout * mainLayout;
         QVBoxLayout * plotLayout;
         QHBoxLayout * lengthLayout;
-        QHBoxLayout * buttonLayout;
 
     public slots:
         void resetPlot();


### PR DESCRIPTION
resize the plot to fill space:
![plot_resize](https://user-images.githubusercontent.com/8226248/102811327-14b1ab00-43bd-11eb-8cbc-b2912322b18d.png)

Before this, the plot size was hard coded to 640x240 which is quite small on HiDPI displays.