### PR TITLE
Added stopwatch decorator for timing python functions with automatic naming

### DIFF
--- a/decorator_test.py
+++ b/decorator_test.py
@@ -1,0 +1,49 @@
+from Stopwatch import Stopwatch, stopwatch
+import time
+
+
+class TestClass:
+    @staticmethod
+    @stopwatch()
+    def decorated():
+        time.sleep(0.25)
+
+
+@stopwatch()
+def decorated():
+    time.sleep(0.50)
+
+
+@stopwatch("auto_timer_custom_name")
+def decorated_named():
+    time.sleep(0.75)
+
+
+def manual():
+    Stopwatch.tick("manual_timer")
+    time.sleep(1.0)
+    Stopwatch.tock("manual_timer")
+
+
+if __name__ == "__main__":
+    TestClass.decorated()
+    decorated()
+    decorated_named()
+    manual()
+
+    Stopwatch.print_all()
+
+    # Check for expected names and times in ms
+    tolerance = 0.05  # 5%
+    expected = {
+        "TestClass.decorated": 250,
+        "decorated": 500,
+        "auto_timer_custom_name": 750,
+        "manual_timer": 1000,
+    }
+    for k, v in Stopwatch.get_timings().items():
+        if k not in expected:
+            raise RuntimeError(f"{k} not in expected timings: {expected.keys()}")
+        vTest = expected[k]
+        if abs(v - vTest) > (tolerance * vTest):
+            raise RuntimeError(f"Unexpected timing delta: {v} vs {vTest} with tolerence {tolerance*100:.1f} %")


### PR DESCRIPTION
This PR proposes adding a python decorator alongside the Stopwatch utility to automatically call Stopwatch.tick / tock with either a custom name (or automatic name based on the function `__qualname__`)

Feel free to remove / change as desired (the python `decorator_test.py` script was to double check the PR but is not needed to land)


```
python decorator_test.py

TestClass.decorated: 255.126ms
decorated: 500.57ms
auto_timer_custom_name: 753.006ms
manual_timer: 1004.074ms
```